### PR TITLE
Replace *msi by .exe in Python installation.

### DIFF
--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -7,7 +7,7 @@ Django is written in Python. We need Python to do anything in Django. Let's star
 
 ### Windows
 
-You can download Python for Windows from the website https://www.python.org/downloads/release/python-351/. After downloading the ***.msi** file, you should run it (double-click on it) and follow the instructions there. It is important to remember the path (the directory) where you installed Python. It will be needed later!
+First check whether your computer is running a 32-bit version or a 64-bit version of Windows at https://support.microsoft.com/en-au/kb/827218. You can download Python for Windows from the website https://www.python.org/downloads/release/python-351/. If your computer is running a **64-bit** version of Windows, download the **Windows x86-64 executable installer**. Otherwise, download the **Windows x86 executable installer**. After downloading the installer, you should run it (double-click on it) and follow the instructions there. It is important to remember the path (the directory) where you installed Python. It will be needed later!
 
 One thing to watch out for:  on the second screen of the installation wizard, marked "Customize", make sure you scroll down to the "Add python.exe to the Path" option and select "Will be installed on local hard drive", as shown here:
 


### PR DESCRIPTION
Remove instructions to install *msi file and replace instructions to install relevant exe installers depending on 32-bit or 64-bit Windows systems.