### PR TITLE
Add instructions to open cmd using Windows+R

### DIFF
--- a/en/python_installation/instructions.md
+++ b/en/python_installation/instructions.md
@@ -13,7 +13,7 @@ One thing to watch out for:  on the second screen of the installation wizard, ma
 
 ![Don't forget to add Python to the Path](../python_installation/images/add_python_to_windows_path.png)
 
-In upcoming steps, you'll be using the Windows Command Line (which we'll also tell you about). For now, if you need to type in some commands, go to Start menu → All Programs → Accessories → Command Prompt. (On newer versions of Windows, you might have to search for "Command Prompt" since it's sometimes hidden.)
+In upcoming steps, you'll be using the Windows Command Line (which we'll also tell you about). For now, if you need to type in some commands, go to Start menu → All Programs → Accessories → Command Prompt. You can also hold in the Windows key and press the "R"-key until a the "Run" window pops up. To open the Command Line, type "cmd" and press enter in the "Run" window. (On newer versions of Windows, you might have to search for "Command Prompt" since it's sometimes hidden.)
 
 ### Linux
 


### PR DESCRIPTION
Add instructions to open the Windows command prompt using the Windows+R shortcut, followed by typing "cmd" in the the "Run" window.